### PR TITLE
Dev

### DIFF
--- a/Currency-Converter/src/currency/Converter.java
+++ b/Currency-Converter/src/currency/Converter.java
@@ -36,7 +36,7 @@ public class Converter {
 		
 		// call desired API request
 		System.out.println("\n");
-		if(endpoint.equals("live"))
+		if("live".equals(endpoint))
 			RequestLive.requestLive(targetCurrencies, amount);
 		
 		input.close();

--- a/Currency-Converter/src/currency/ErrorCodeHandler.java
+++ b/Currency-Converter/src/currency/ErrorCodeHandler.java
@@ -11,7 +11,7 @@ public final class ErrorCodeHandler {
 	private ErrorCodeHandler() {
 	}
 	
-	public static void errorHandler(JSONObject rate){
+	public static void errorHandler(JSONObject rate) {
 		int errorCode = rate.getJSONObject("error").getInt("code");
 		switch(errorCode) {
 		
@@ -42,8 +42,10 @@ public final class ErrorCodeHandler {
 		case 302:  System.out.println("Invalid date");
 		break;
 		
+		default: System.out.println("Unknown error has occured");
+		break;
 		}
-		System.exit(1);
+
 	}
 
 	

--- a/Currency-Converter/src/currency/Readfile.java
+++ b/Currency-Converter/src/currency/Readfile.java
@@ -14,7 +14,6 @@ class Readfile {
 			return key;
 		} catch(FileNotFoundException e) {
 			System.out.println("API key file not found");
-			System.exit(1);
 		} catch (IOException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();

--- a/Currency-Converter/src/currency/RequestLive.java
+++ b/Currency-Converter/src/currency/RequestLive.java
@@ -48,7 +48,7 @@ public final class RequestLive {
 				
 				// converts response to java object
 				JSONObject rate = new JSONObject(EntityUtils.toString(entity));
-				if(rate.getBoolean("success") == false) {
+				if(!rate.getBoolean("success")) {
 					ErrorCodeHandler.errorHandler(rate);
 				}
 				else {
@@ -82,6 +82,9 @@ public final class RequestLive {
 				// TODO Auto-generated catch block
 				e.printStackTrace();
 			} catch (IOException e) {
+				// TODO Auto-generated catch block
+				e.printStackTrace();
+			} catch (Exception e) {
 				// TODO Auto-generated catch block
 				e.printStackTrace();
 			}


### PR DESCRIPTION
System.exit(1) s in my code were unnecessary and bad practice, cleaned up string comparison functions and added a default label to ErrorHandler's switch statement.